### PR TITLE
Add reasonable rules that take effect immediatly

### DIFF
--- a/data/90-rogauracore.rules
+++ b/data/90-rogauracore.rules
@@ -1,8 +1,9 @@
 # udev rules for user control over ROG USB RGB keyboard backlight control (i.e "ROG Aura Core")
 
 # GL553, GL753
-ACTION=="add", SUBSYSTEM=="usb", ATTRS{idVendor}=="0b05", ATTRS{idProduct}=="1854", MODE="0666", TAG+="uaccess"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="0b05", ATTRS{idProduct}=="1854", GROUP="users", MODE="0660"
 # GL503, FX503, GL703
-ACTION=="add", SUBSYSTEM=="usb", ATTRS{idVendor}=="0b05", ATTRS{idProduct}=="1869", MODE="0666", TAG+="uaccess"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="0b05", ATTRS{idProduct}=="1869", GROUP="users", MODE="0660"
 # GL504, GL703, GX501, GM501
-ACTION=="add", SUBSYSTEM=="usb", ATTRS{idVendor}=="0b05", ATTRS{idProduct}=="1866", MODE="0666", TAG+="uaccess"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="0b05", ATTRS{idProduct}=="1866", GROUP="users", MODE="0660"
+


### PR DESCRIPTION
These rules take effect immediately and provide a little more security. Only users in the group `users` will be able to interact with the device. Created them from your package when I was looking into including some udev rules in my AUR package. Figure I would return the favor.